### PR TITLE
Support nested namespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const raf = require('random-access-file')
 
 const MASTER_KEY_FILENAME = 'master_key'
 const NAMESPACE = 'corestore'
+const NAMESPACE_SEPERATOR = ':'
 
 class NamespacedCorestore {
   constructor (corestore, name) {
@@ -50,6 +51,11 @@ class NamespacedCorestore {
   replicate (discoveryKey, opts) {
     // TODO: This should only replicate the cores in this._opened.
     return this.store.replicate(discoveryKey, { ...opts, cores: this._opened })
+  }
+
+  namespace (name) {
+    if (Buffer.isBuffer(name)) name = name.toString('hex')
+    return this.store.namespace(this.name + NAMESPACE_SEPERATOR + name)
   }
 
   close (cb) {
@@ -300,8 +306,10 @@ class Corestore extends EventEmitter {
 
   namespace (name) {
     if (!name) name = hypercoreCrypto.randomBytes(32)
+    if (Buffer.isBuffer(name)) name = name.toString('hex')
+    if (this._namespaces.has(name)) return this._namespaces.get(name)
     const ns = new NamespacedCorestore(this, name)
-    this._namespaces.set(name.toString('hex'), ns)
+    this._namespaces.set(name, ns)
     return ns
   }
 

--- a/test/all.js
+++ b/test/all.js
@@ -371,6 +371,27 @@ test('namespaced corestores will not increment reference multiple times', async 
   t.end()
 })
 
+test('namespaced corestores can be nested', async t => {
+  const store1 = await create(ram)
+  const store2 = store1.namespace('store2')
+  const store1a = store1.namespace('a')
+  const store2a = store2.namespace('a')
+
+  const feed1 = store1.default()
+  const feed2 = store2.default()
+  const feed1a = store1a.default()
+  const feed2a = store2a.default()
+
+  await feed1.ready()
+  await feed2.ready()
+  await feed1a.ready()
+  await feed2a.ready()
+
+  t.notEqual(feed1a.key, feed2a.key)
+
+  t.end()
+})
+
 test('caching works correctly when reopening by discovery key', async t => {
   var store = await create('test-store')
   var firstCore = store.default()


### PR DESCRIPTION
Allows to nest namespaces. Nested namespaces don't keep a relation to their parent, their names are simply appended with a seperator.

See #10 