### PR TITLE
Support onwrite hook with key as first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Opts is an optional object which can contain any Hypercore constructor options, 
 ```js
 {
   cacheSize: 1000 // The size of the LRU cache for passively-replicating cores.
+  onwrite: (key, index, data, peer, cb) // set the onwrite option for each hypercore,
+                                        // but the callback gets the feed key as first argument
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -347,6 +347,12 @@ class Corestore extends EventEmitter {
     if (cacheOpts.data) cacheOpts.data = cacheOpts.data.namespace()
     if (cacheOpts.tree) cacheOpts.tree = cacheOpts.tree.namespace()
 
+    if (!coreOpts.onwrite && this.opts.onwrite) {
+      coreOpts.onwrite = function (index, data, peer, cb) {
+        self.opts.onwrite(publicKey, index, data, peer, cb)
+      }
+    }
+
     const core = hypercore(name => {
       if (name === 'key') return keyStorage.key
       if (name === 'secret_key') return keyStorage.secretKey


### PR DESCRIPTION
This adds an `onwrite` option that is passed into each hypercore, but the callback gets the feed key as first argument. See #12 for details and motivation.