### PR TITLE
enable custom master key

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class Corestore extends Nanoresource {
     })
 
     // Generated in _open
-    this._masterKey = null
+    this._masterKey = opts.masterKey || null
     this._id = hypercoreCrypto.randomBytes(8)
   }
 
@@ -138,6 +138,7 @@ class Corestore extends Nanoresource {
   }
 
   _open (cb) {
+    if (this._masterKey) return cb()
     const keyStorage = this.storage(MASTER_KEY_FILENAME)
     keyStorage.read(0, 32, (err, key) => {
       if (err) {


### PR DESCRIPTION
Allows the generation and use of master key to happen external to corestore. In cobox we're using our own key derivation function to determine the keys for each hypercore. I'm currently trying to switch to use corestore for storage and multifeed's mux for replication, but don't want to be coupled to corestore's key generation.