### PR TITLE
Changes to ref counting and namespace handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 5.7.0
+- Simplifies internal reference counting and namespace handling. This removes the `NamespacedCorestore` class, but does not alter the interface.
+- Uses `refpool` for reference handling.
+- Removes `Nanoguard` and the undocumented `this.guard` property on Corestore.
+- Removes the private `_name` option to `Corestore.get` in favor of a public `name` option.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const HypercoreProtocol = require('hypercore-protocol')
 const Nanoresource = require('nanoresource/emitter')
-const Nanoguard = require('nanoguard')
 const hypercore = require('hypercore')
 const hypercoreCrypto = require('hypercore-crypto')
 const datEncoding = require('dat-encoding')
@@ -22,7 +21,6 @@ class InnerCorestore extends Nanoresource {
     if (typeof storage === 'string') storage = defaultStorage(storage)
     if (typeof storage !== 'function') throw new Error('Storage should be a function or string')
     this.storage = storage
-    this.guard = new Nanoguard()
 
     this.opts = opts
 
@@ -224,7 +222,6 @@ class InnerCorestore extends Nanoresource {
       cache: cacheOpts,
       createIfMissing: !!publicKey
     })
-    core.ifAvailable.depend(this.guard)
 
     this.cache.set(id, core)
     core.ifAvailable.wait()

--- a/index.js
+++ b/index.js
@@ -372,9 +372,7 @@ class Corestore extends Nanoresource {
 
   default (coreOpts = {}) {
     if (Buffer.isBuffer(coreOpts)) coreOpts = { key: coreOpts }
-    const core = this.inner.get({ ...coreOpts, name: this.name })
-    this._maybeIncrement(core)
-    return core
+    return this.get({ ...coreOpts, name: this.name })
   }
 
   namespace (name) {

--- a/index.js
+++ b/index.js
@@ -317,6 +317,15 @@ class Corestore extends Nanoresource {
     this._isNamespaced = !!opts.name
     this._isTopLevel = !opts.inner
     this._openedCores = new Map()
+
+    const onfeed = feed => this.emit('feed', feed)
+    const onerror = err => this.emit('error', err)
+    this.inner.on('feed', onfeed)
+    this.inner.on('error', onerror)
+    this._unlisten = () => {
+      this.inner.removeListener('feed', onfeed)
+      this.inner.removeListener('error', onerror)
+    }
   }
 
   ready (cb) {
@@ -335,6 +344,7 @@ class Corestore extends Nanoresource {
   }
 
   _close (cb) {
+    this._unlisten()
     if (this._isTopLevel) return this.inner.close(cb)
     for (const dkey of this._openedCores) {
       this.cache.decrement(dkey)

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "hypercore": "^9.0.0",
     "hypercore-crypto": "^2.0.0",
     "hypercore-protocol": "^8.0.0",
-    "lru": "^3.1.0",
     "nanoguard": "^1.3.0",
     "nanoresource": "^1.3.0",
-    "refpool": "^1.2.0",
-    "thunky": "^1.1.0"
+    "refpool": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lru": "^3.1.0",
     "nanoguard": "^1.3.0",
     "nanoresource": "^1.3.0",
+    "refpool": "^1.2.0",
     "thunky": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "hypercore": "^9.0.0",
     "hypercore-crypto": "^2.0.0",
     "hypercore-protocol": "^8.0.0",
-    "nanoguard": "^1.3.0",
     "nanoresource": "^1.3.0",
     "refpool": "^1.2.0"
   }

--- a/test/all.js
+++ b/test/all.js
@@ -366,7 +366,9 @@ test('namespaced corestores will not increment reference multiple times', async 
   t.same(feed1, feed3)
   t.same(feed1, feed4)
   t.same(feed1, feed5)
-  t.same(store1._references.get(feed1), 2)
+
+  const entry = store1.cache.entry(feed1.discoveryKey.toString('hex'))
+  t.same(entry.refs, 2)
 
   t.end()
 })
@@ -419,7 +421,7 @@ test('caching works correctly when reopening by discovery key', async t => {
     },
     cb => {
       const idx = discoveryKey.toString('hex')
-      t.true(store._internalCores.get(idx))
+      t.true(store.cache.has(idx))
       return cb(null)
     }
   ])


### PR DESCRIPTION
Reference counting was previously tightly coupled to the corestore logic, which was making session handling in Hyperspace challenging. This PR updates the ref counting to use the `refpool` module, which simplifies many things.

To make things even simpler, the main logic has been extracted into an InnerCorestore class, which doesn't handle namespacing or reference counting. The exported Corestore class wraps InnerCorestore and adds ref counting.

The addition of InnerCorestore also lets us massively simplify namespace handling. A second NamespacedCorestore class is no longer necessary. This change is totally backwards-compat.