### PR TITLE
Max emitters test and fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,10 @@ class Corestore extends Nanoresource {
     this._isNamespaced = !!opts.name
     this._openedCores = new Map()
 
-    const onfeed = feed => this.emit('feed', feed)
+    const onfeed = feed => {
+      this.emit('feed', feed)
+      this._unlisten()
+    }
     const onerror = err => this.emit('error', err)
     this.inner.on('feed', onfeed)
     this.inner.on('error', onerror)

--- a/test/stress.js
+++ b/test/stress.js
@@ -1,13 +1,13 @@
 /**
  * Makes a couple dozen namespaced corestores
- * 
+ *
  * For example, kappa-mulitfeed makes a new corestore for each new multifeed
- * 
+ *
  * When more than 11 corestores are made, a MaxListenersExceededWarning happens
  * due to too many listeners, see:
- * 
+ *
  * https://github.com/andrewosh/corestore/issues/20
- * 
+ *
  */
 const ram = require('random-access-memory')
 const test = require('tape')

--- a/test/stress.js
+++ b/test/stress.js
@@ -1,10 +1,13 @@
 /**
  * Makes a couple dozen namespaced corestores
- * Point is, every time a new corestore is made event listeners for 'feed' and 'error' are
- * added but never removed unless the namespace is closed.
- *
- * emit 'feed' seems to be only needed for onready,
- * if _unlisten is added after onready emits feed, this test passes
+ * 
+ * For example, kappa-mulitfeed makes a new corestore for each new multifeed
+ * 
+ * When more than 11 corestores are made, a MaxListenersExceededWarning happens
+ * due to too many listeners, see:
+ * 
+ * https://github.com/andrewosh/corestore/issues/20
+ * 
  */
 const ram = require('random-access-memory')
 const test = require('tape')
@@ -23,6 +26,7 @@ test('make a couple dozen namespaced corestores (without MaxListener warning)', 
       cores[index] = spaces[index].default()
       await cores[index].ready()
 
+      // feed and event never passes 3 listeners
       t.ok(store.inner._events.feed.length < 3, '## feed event listener length before is only 1 or 2')
       t.ok(spaces[index].inner._events.feed.length < 3, '## feed event listener length before is only 1 or 2')
       t.ok(store.inner._events.error.length < 3, '## feed event listener length before is only 1 or 2')
@@ -30,6 +34,7 @@ test('make a couple dozen namespaced corestores (without MaxListener warning)', 
 
       await once(store.inner, 'feed')
 
+      // feed and event never passes 0 listeners
       t.ok(store.inner._events.feed === undefined, '## feed event listener length after is zero')
       t.ok(spaces[index].inner._events.feed === undefined, '## feed event listener length after is zero')
       t.ok(store.inner._events.error === undefined, '## feed event listener length after is zero')

--- a/test/stress.js
+++ b/test/stress.js
@@ -1,0 +1,51 @@
+/**
+ * Makes a couple dozen namespaced corestores
+ * Point is, every time a new corestore is made event listeners for 'feed' and 'error' are
+ * added but never removed unless the namespace is closed.
+ *
+ * emit 'feed' seems to be only needed for onready,
+ * if _unlisten is added after onready emits feed, this test passes
+ */
+const ram = require('random-access-memory')
+const test = require('tape')
+const Corestore = require('..')
+const { once } = require('events')
+
+test('make a couple dozen namespaced corestores (without MaxListener warning)', async t => {
+  const store = await create(ram)
+  let spaces = []
+  let cores = []
+
+  let index = 0
+  while (index < 24) {
+    try {
+      spaces[index] = store.namespace('namespace-' + index)
+      cores[index] = spaces[index].default()
+      await cores[index].ready()
+
+      t.ok(store.inner._events.feed.length < 3, '## feed event listener length before is only 1 or 2')
+      t.ok(spaces[index].inner._events.feed.length < 3, '## feed event listener length before is only 1 or 2')
+      t.ok(store.inner._events.error.length < 3, '## feed event listener length before is only 1 or 2')
+      t.ok(spaces[index].inner._events.error.length < 3, '## feed event listener length before is only 1 or 2')
+
+      await once(store.inner, 'feed')
+
+      t.ok(store.inner._events.feed === undefined, '## feed event listener length after is zero')
+      t.ok(spaces[index].inner._events.feed === undefined, '## feed event listener length after is zero')
+      t.ok(store.inner._events.error === undefined, '## feed event listener length after is zero')
+      t.ok(spaces[index].inner._events.error === undefined, '## feed event listener length after is zero')
+    } catch (err) {
+      console.error('error happened', err)
+    }
+    t.ok(store.inner._events.feed === undefined, 'no event listner memory leak')
+    index++
+  }
+
+  t.end()
+})
+
+async function create (storage, opts) {
+  const store = new Corestore(storage, opts)
+  await store.ready()
+  return store
+}


### PR DESCRIPTION
PR Addressing: https://github.com/andrewosh/corestore/issues/20

I wrote this test to make a couple dozen namespaced corestores, like what happens in kappa-multifeed (https://github.com/kappa-db/multifeed/pull/45). 

With the current `inner.on.('feed'` setup it emits the `MaxListener` warning due to ever increasing event listeners on `'feed'` and `'error'`.

When I add the unlisten event after `'feed'` is emitted (since it appears to only emit once), the events array doesn't build up and the Max emitters and memory leak is fixed. I thought about also adding `unlisten` after `'error'` is emitted, but was unsure whether that might break something elsewhere. But it is an option too in case there are a lot of errors on many corestores?

For your consideration 