### PR TITLE
Fixing timing error that can cause double replication of feeds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,9 @@ class InnerCorestore extends Nanoresource {
     var closed = false
 
     for (const core of cores) {
-      this._replicateCore(isInitiator, core, mainStream, { ...finalOpts })
+      if (core.opened) {
+        this._replicateCore(isInitiator, core, mainStream, { ...finalOpts })
+      }
     }
 
     mainStream.on('discovery-key', ondiscoverykey)


### PR DESCRIPTION
I noticed that cores in the process of being opened where replicated twice. This PR should fix the issue.