### PR TITLE
feat(replicate): support store.replicate(protomux)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "b4a": "^1.3.1",
-    "hypercore": "v10.0.0",
+    "hypercore": "^10.2.0",
     "hypercore-crypto": "^3.2.1",
     "safety-catch": "^1.0.1",
     "sodium-universal": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "b4a": "^1.3.1",
     "hypercore": "v10.0.0",
     "hypercore-crypto": "^3.2.1",
+    "protomux": "^3.3.0",
     "safety-catch": "^1.0.1",
     "sodium-universal": "^3.0.4",
     "xache": "^1.1.0"


### PR DESCRIPTION
Multiplexing `corestore.replicate()` with other `protomux` either close or
restart the connection see [here](https://gist.github.com/Nazeh/a3f1d24b597913303afcb6c568f4b042).

The solution seems to be passing the same `Protomux` instance to both `hypercore.replicate()` and other multiplexed applications, see [here](https://gist.github.com/Nazeh/04f7b57aeaeaf933b6ea6fd7925f613b#file-successful_corestore_replicate_and_protomux_rpc-js-L21).

Still Corestore currently forces the creation of a new stream [here](https://github.com/hypercore-protocol/corestore/blob/master/index.js#L258), hence this PR.

While I didn't add a unit test (to avoid importing `@hyperswarm/secret-stream`, you can see the new `corestore.replicate()` function in action [here](https://gist.github.com/Nazeh/04f7b57aeaeaf933b6ea6fd7925f613b#file-successful_corestore_replicate_and_protomux_rpc-js-L57)