### PR TITLE
Namespaced close should actually close sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ module.exports = class Corestore extends EventEmitter {
   async _close () {
     await this._opening
     await this._closeNamespace()
-    if (this._keyStorage) {
+    if (this._root === this) {
       await this._closePrimaryNamespace()
     }
   }

--- a/index.js
+++ b/index.js
@@ -230,6 +230,7 @@ module.exports = class Corestore extends EventEmitter {
   }
 
   get (opts = {}) {
+    if (this._root._closing) throw new Error('The corestore is closed')
     opts = validateGetOptions(opts)
 
     if (opts.cache !== false) {

--- a/index.js
+++ b/index.js
@@ -297,14 +297,9 @@ module.exports = class Corestore extends EventEmitter {
 
   async _close () {
     await this._opening
-    if (!b4a.equals(this._namespace, DEFAULT_NAMESPACE)) {
-      // namespaces should not release resources on close
-      // TODO: Refactor the namespace close logic to actually close sessions with ref counting
-      return
-    }
     const closePromises = []
-    for (const core of this.cores.values()) {
-      closePromises.push(core.close())
+    for (const session of this._sessions) {
+      closePromises.push(session.close())
     }
     await Promise.allSettled(closePromises)
     for (const { stream, isExternal } of this._replicationStreams) {

--- a/test/all.js
+++ b/test/all.js
@@ -364,9 +364,13 @@ test('closing the root corestore closes all sessions', async function (t) {
   const store = new Corestore(ram)
   const ns = store.namespace('test-namespace')
 
-  const core1 = ns.get({ name: 'core-1' })
-  const core2 = ns.get({ name: 'core-2' })
+  const core1 = store.get({ name: 'core-1' })
+  const core2 = store.get({ name: 'core-2' })
   await Promise.all([core1.ready(), core2.ready()])
+
+  const core3 = ns.get(core1.key)
+  const core4 = ns.get(core2.key)
+  await Promise.all([core3.ready(), core4.ready()])
 
   await store.close()
 

--- a/test/all.js
+++ b/test/all.js
@@ -376,6 +376,14 @@ test('closing the root corestore closes all sessions', async function (t) {
 
   t.is(core1.closed, true)
   t.is(core2.closed, true)
+
+  try {
+    const core5 = ns.get({ name: 'core-3' })
+    await core5.ready()
+    t.fail('core5 should not have opened after corestore close')
+  } catch (err) {
+    t.pass('core5 did not open after corestore close')
+  }
 })
 
 function tmpdir () {

--- a/test/all.js
+++ b/test/all.js
@@ -223,12 +223,16 @@ test('storage locking', async function (t) {
   }
 })
 
-test('closing a namespace does not close cores', async function (t) {
+test('cores close when their last referencing namespace closes', async function (t) {
   const store = new Corestore(ram)
   const ns1 = store.namespace('ns1')
   const core1 = ns1.get({ name: 'core-1' })
   const core2 = ns1.get({ name: 'core-2' })
   await Promise.all([core1.ready(), core2.ready()])
+
+  const core3 = store.get(core1.key)
+  const core4 = store.get(core2.key)
+  await Promise.all([core3.ready(), core4.ready()])
 
   await ns1.close()
 

--- a/test/all.js
+++ b/test/all.js
@@ -345,6 +345,20 @@ test('core caching after reopen regression', async function (t) {
   t.pass('did not infinite loop')
 })
 
+test('closing a namespace does not close the root corestore', async function (t) {
+  const store = new Corestore(ram)
+  const core1 = store.get({ name: 'core-1' })
+  await core1.ready()
+
+  const ns = store.namespace('test-namespace')
+  const core2 = ns.get(core1.key)
+  await core2.ready()
+
+  await ns.close()
+  t.is(core1.closed, false)
+  t.is(core2.closed, true)
+})
+
 test('open a new session concurrently with a close should throw', async function (t) {
   const store = new Corestore(ram)
   const ns = store.namespace('test-namespace')


### PR DESCRIPTION
When you call `close` on a namespaced store, it will currently short-circuit without actually closing core sessions. Think this is legacy behavior from before we added `findingPeers` (which also added the session tracking per-namespace).
