### PR TITLE
Add core-open and core-close events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Useful when an application wants to accept an optional Corestore, but needs to m
 }
 ```
 
+#### `store.on('core-open', core)`
+Emitted when the first session for a core is opened.
+
+*Note: This core may close at any time, so treat it as a weak reference*
+
+#### `store.on('core-close', core)
+Emitted when the last session for a core is closed.
+
 ### License
 MIT
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Emitted when the first session for a core is opened.
 
 *Note: This core may close at any time, so treat it as a weak reference*
 
-#### `store.on('core-close', core)
+#### `store.on('core-close', core)`
 Emitted when the last session for a core is closed.
 
 ### License

--- a/index.js
+++ b/index.js
@@ -201,6 +201,7 @@ module.exports = class Corestore extends EventEmitter {
     this.cores.set(id, core)
     core.ready().then(() => {
       if (core.closing) return // extra safety here as ready is a tick after open
+      this.emit('core-open', core)
       for (const { stream } of this._replicationStreams) {
         core.replicate(stream, { session: true })
       }
@@ -208,6 +209,7 @@ module.exports = class Corestore extends EventEmitter {
       this.cores.delete(id)
     })
     core.once('close', () => {
+      this.emit('core-close', core)
       this.cores.delete(id)
     })
     core.on('conflict', (len, fork, proof) => {


### PR DESCRIPTION
The events will trigger whenever the first session for a given core is opened, and whenever the last session is closed.

The contract is that the emitted core can close at any time, so should treat it as a weak reference.