### PR TITLE
Add ability to create a namespace from a bootstrap core

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = class Corestore extends EventEmitter {
     this.primaryKey = opts.primaryKey || null
 
     this._keyStorage = null
+    this._bootstrap = opts.bootstrap
     this._namespace = opts.namespace || DEFAULT_NAMESPACE
 
     this._root = root || this
@@ -81,10 +82,17 @@ module.exports = class Corestore extends EventEmitter {
     }
   }
 
+  async _openNamespaceFromBootstrap () {
+    const ns = await this._bootstrap.getUserData(USERDATA_NAMESPACE_KEY)
+    if (!ns) throw new Error('Invalid bootstrap namespace')
+    this._namespace = ns
+  }
+
   async _open () {
     if (this._root !== this) {
       await this._root._opening
       if (!this.primaryKey) this.primaryKey = this._root.primaryKey
+      if (this._bootstrap) await this._openNamespaceFromBootstrap()
       return
     }
 
@@ -107,6 +115,8 @@ module.exports = class Corestore extends EventEmitter {
         })
       })
     })
+
+    if (this._bootstrap) await this._openNamespaceFromBootstrap()
   }
 
   async _generateKeys (opts) {
@@ -302,7 +312,11 @@ module.exports = class Corestore extends EventEmitter {
   }
 
   namespace (name) {
-    return this.session({ namespace: generateNamespace(this._namespace, name) })
+    if (name instanceof Hypercore) {
+      return this.session({ bootstrap: name })
+    } else {
+      return this.session({ namespace: generateNamespace(this._namespace, name) })
+    }
   }
 
   session (opts) {

--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ module.exports = class Corestore extends EventEmitter {
 
   async _openNamespaceFromBootstrap () {
     const ns = await this._bootstrap.getUserData(USERDATA_NAMESPACE_KEY)
-    if (!ns) throw new Error('Invalid bootstrap namespace')
-    this._namespace = ns
+    if (ns) {
+      this._namespace = ns
+    }
   }
 
   async _open () {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = class Corestore extends EventEmitter {
     this.primaryKey = opts.primaryKey || null
 
     this._keyStorage = null
-    this._bootstrap = opts.bootstrap
+    this._bootstrap = opts.bootstrap || null
     this._namespace = opts.namespace || DEFAULT_NAMESPACE
 
     this._root = root || this
@@ -315,9 +315,8 @@ module.exports = class Corestore extends EventEmitter {
   namespace (name) {
     if (name instanceof Hypercore) {
       return this.session({ bootstrap: name })
-    } else {
-      return this.session({ namespace: generateNamespace(this._namespace, name) })
-    }
+    } 
+    return this.session({ namespace: generateNamespace(this._namespace, name) })
   }
 
   session (opts) {

--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ module.exports = class Corestore extends EventEmitter {
   namespace (name) {
     if (name instanceof Hypercore) {
       return this.session({ bootstrap: name })
-    } 
+    }
     return this.session({ namespace: generateNamespace(this._namespace, name) })
   }
 

--- a/test/all.js
+++ b/test/all.js
@@ -495,7 +495,7 @@ test('opening a namespace from a bootstrap core', async function (t) {
   t.alike(bootstrap1.key, bootstrap2.key)
 })
 
-test('opening a namespace from an invalid bootstrap core', async function (t) {
+test('opening a namespace from an invalid bootstrap core is a no-op', async function (t) {
   const store1 = new Corestore(ram)
   const store2 = new Corestore(ram)
 
@@ -505,8 +505,9 @@ test('opening a namespace from an invalid bootstrap core', async function (t) {
 
   const bootstrap2 = store2.get(bootstrap1.key)
   const ns2 = store2.namespace(bootstrap2)
+  await ns2.ready()
 
-  await t.exception(ns2.ready())
+  t.alike(ns2._namespace, store2._namespace)
 })
 
 function tmpdir () {

--- a/test/all.js
+++ b/test/all.js
@@ -482,6 +482,33 @@ test('core-open and core-close events', async function (t) {
   t.is(closed, 2)
 })
 
+test('opening a namespace from a bootstrap core', async function (t) {
+  const store = new Corestore(ram)
+
+  const ns1 = store.namespace(crypto.randomBytes(32))
+  const bootstrap1 = ns1.get({ name: 'bootstrap' })
+
+  const ns2 = store.namespace(bootstrap1)
+  const bootstrap2 = ns2.get({ name: 'bootstrap' })
+
+  await Promise.all([bootstrap1.ready(), bootstrap2.ready()])
+  t.alike(bootstrap1.key, bootstrap2.key)
+})
+
+test('opening a namespace from an invalid bootstrap core', async function (t) {
+  const store1 = new Corestore(ram)
+  const store2 = new Corestore(ram)
+
+  const ns1 = store1.namespace(crypto.randomBytes(32))
+  const bootstrap1 = ns1.get({ name: 'bootstrap' })
+  await bootstrap1.ready()
+
+  const bootstrap2 = store2.get(bootstrap1.key)
+  const ns2 = store2.namespace(bootstrap2)
+
+  await t.exception(ns2.ready())
+})
+
 function tmpdir () {
   return path.join(os.tmpdir(), 'corestore-' + Math.random().toString(16).slice(2))
 }


### PR DESCRIPTION
Creating a bootstrap core from a random namespace is a pretty common Corestore pattern. Later, when reloading cores from the bootstrap key, one has to read the `namespace` userdata from the bootstrap core in order to re-create the same namespace. 

This PR adds the ability to pass a bootstrap core to `store.namespace`. This will open a namespace that's identical to the one that was used to initially create the bootstrap core.