### PR TITLE
Root sessions should emit core-open and core-close events

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,9 +365,7 @@ module.exports = class Corestore extends EventEmitter {
 
   async _close () {
     await this._opening
-    if (this._root._rootStoreSessions.has(this)) {
-      this._root._rootStoreSessions.delete(this)
-    }
+    this._root._rootStoreSessions.delete(this)
     await this._closeNamespace()
     if (this._root === this) {
       await this._closePrimaryNamespace()


### PR DESCRIPTION
`core-open` and `core-close` events are emitted on the core's namespace, as well as on the root store. Sessions created on the root corestore should also emit these events.