### PR TITLE
Document Corestore.close in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Useful when an application wants to accept an optional Corestore, but needs to m
 }
 ```
 
+#### `await store.close()`
+Fully close this Corestore instance.
+
 #### `store.on('core-open', core)`
 Emitted when the first session for a core is opened.
 


### PR DESCRIPTION
Addresses #72 

II don't know where the source for docs.holepunch.to come from, so I'm not sure if  this change will be reflected there. Please point me to the source for those other docs and I will change those too.