### PR TITLE
Bump hypercore min v to be compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "b4a": "^1.6.4",
-    "hypercore": "^10.28.1",
+    "hypercore": "^10.32.2",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",
     "read-write-mutexify": "^2.1.0",


### PR DESCRIPTION
Current corestore tests don't pass with old versions of hypercore, so it seems better to make the min version explicit