### PR TITLE
Early return in replicate's ondiscoverKey if closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,6 +430,8 @@ module.exports = class Corestore extends ReadyResource {
     const stream = Hypercore.createProtocolStream(isInitiator, {
       ...opts,
       ondiscoverykey: async discoveryKey => {
+        if (this.closing) return
+
         const id = b4a.toString(discoveryKey, 'hex')
         if (this._noCoreCache.get(id)) return
 


### PR DESCRIPTION
This avoids throwing in some edge cases. For example, when a corestore is closed before a hyperswarm, the ondiscoveryKey callback can still trigger, causing an error like

```
Error: The corestore is closed
at Corestore.get (.../node_modules/corestore/index.js:376:51)
    at ondiscoverykey (.../node_modules/corestore/index.js:436:27)
    ...
    at ReadableState.update (.../node_modules/streamx/index.js:344:12
...

Closing a corestore before the swarm might also just be undefined behaviour though, in which case: feel free to close