### PR TITLE
Support globalCache opt

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = class Corestore extends ReadyResource {
     this.manifestVersion = typeof opts.manifestVersion === 'number' ? opts.manifestVersion : (root ? root.manifestVersion : DEFAULT_MANIFEST)
     this.compat = typeof opts.compat === 'boolean' ? opts.compat : (root ? root.compat : DEFAULT_COMPAT)
     this.inflightRange = opts.inflightRange || null
+    this.globalCache = opts.globalCache || null
 
     this._keyStorage = null
     this._bootstrap = opts._bootstrap || null
@@ -319,6 +320,7 @@ module.exports = class Corestore extends ReadyResource {
       key,
       compat: opts.compat,
       cache: opts.cache,
+      globalCache: this.globalCache,
       createIfMissing: opts.createIfMissing === false ? false : !opts._discoveryKey,
       keyPair: hasKeyPair ? keyPair : null
     })
@@ -392,6 +394,7 @@ module.exports = class Corestore extends ReadyResource {
 
     const core = new Hypercore(null, {
       ...opts,
+      globalCache: this.globalCache,
       name: null,
       preload: async () => {
         if (opts.preload) opts = { ...opts, ...(await opts.preload()) }

--- a/index.js
+++ b/index.js
@@ -492,6 +492,7 @@ module.exports = class Corestore extends ReadyResource {
       _attached: opts && opts.detach === false ? this : null,
       _root: this._root,
       inflightRange: this.inflightRange,
+      globalCache: this.globalCache,
       ...opts
     })
     if (this === this._root) this._rootStoreSessions.add(session)

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = class Corestore extends ReadyResource {
     this.manifestVersion = typeof opts.manifestVersion === 'number' ? opts.manifestVersion : (root ? root.manifestVersion : DEFAULT_MANIFEST)
     this.compat = typeof opts.compat === 'boolean' ? opts.compat : (root ? root.compat : DEFAULT_COMPAT)
     this.inflightRange = opts.inflightRange || null
-    this.globalCache = opts.globalCache || null // Unofficial option, only use if you know what you are doing (no semver guarantees)
+    this.globalCache = opts.globalCache || null
 
     this._keyStorage = null
     this._bootstrap = opts._bootstrap || null

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = class Corestore extends ReadyResource {
     this.manifestVersion = typeof opts.manifestVersion === 'number' ? opts.manifestVersion : (root ? root.manifestVersion : DEFAULT_MANIFEST)
     this.compat = typeof opts.compat === 'boolean' ? opts.compat : (root ? root.compat : DEFAULT_COMPAT)
     this.inflightRange = opts.inflightRange || null
-    this.globalCache = opts.globalCache || null
+    this.globalCache = opts.globalCache || null // Unofficial option, only use if you know what you are doing (no semver guarantees)
 
     this._keyStorage = null
     this._bootstrap = opts._bootstrap || null

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "b4a": "^1.6.4",
-    "hypercore": "holepunchto/hypercore#rache-global-approach",
+    "hypercore": "^10.37.10",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",
     "read-write-mutexify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "random-access-memory": "^6.2.0",
     "standard": "^17.1.0",
     "test-tmp": "^1.0.2",
-    "rache": "^0.0.3"
+    "rache": "^1.0.0"
   },
   "dependencies": {
     "b4a": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "brittle": "^3.2.2",
     "random-access-memory": "^6.2.0",
     "standard": "^17.1.0",
-    "test-tmp": "^1.0.2"
+    "test-tmp": "^1.0.2",
+    "rache": "^0.0.3"
   },
   "dependencies": {
     "b4a": "^1.6.4",
-    "hypercore": "^10.32.3",
+    "hypercore": "holepunchto/hypercore#rache-global-approach",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",
     "read-write-mutexify": "^2.1.0",

--- a/test/cache.js
+++ b/test/cache.js
@@ -51,7 +51,9 @@ test('global cache used by all derived cores', async t => {
   const store = new Corestore(RAM, { globalCache })
 
   const core = store.get({ name: 'core' })
+  await core.ready()
   const core2 = store.get({ name: 'core2' })
+  await core2.ready()
 
   t.is(core.globalCache, globalCache, 'passed to generated core')
   t.is(core.globalCache, core2.globalCache, 'sanity check')

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const RAM = require('random-access-memory')
+const Rache = require('rache')
 
 const Corestore = require('..')
 
@@ -43,4 +44,15 @@ test('core cache on namespace', async function (t) {
 
   t.ok(c1.cache)
   t.ok(c2.cache)
+})
+
+test('global cache used by all derived cores', async t => {
+  const globalCache = new Rache()
+  const store = new Corestore(RAM, { globalCache })
+
+  const core = store.get({ name: 'core' })
+  const core2 = store.get({ name: 'core2' })
+
+  t.is(core.globalCache, globalCache, 'passed to generated core')
+  t.is(core.globalCache, core2.globalCache, 'sanity check')
 })


### PR DESCRIPTION
Depends on https://github.com/holepunchto/hypercore/pull/535 (hence draft)

Passing in a [`Rache`](https://github.com/holepunchto/rache) as the value of `globalCache` will pass that `globalCache` on to every Hypercore created with the corestore, so they can all use the shared cache.