### PR TITLE
remove url references to github.com/holepunchto/corestore2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/holepunchto/corestore2.git"
+    "url": "https://github.com/holepunchto/corestore.git"
   },
   "author": "Holepunch Inc",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/holepunchto/corestore2/issues"
+    "url": "https://github.com/holepunchto/corestore/issues"
   },
-  "homepage": "https://github.com/holepunchto/corestore2"
+  "homepage": "https://github.com/holepunchto/corestore"
 }


### PR DESCRIPTION
Clean up refrences in package.json from github.com/holepunchto/corestore2 to github.com/holepunchto/corestore