### PR TITLE
skip flush on readonly

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,7 +297,8 @@ class Corestore extends ReadyResource {
 
   async suspend({ log = noop } = {}) {
     await log('Flushing db...')
-    await this.storage.db.flush()
+    // If readOnly we don't need to flush
+    if (!this.storage.readOnly) await this.storage.db.flush()
     if (!this.shouldSuspend) return
     await log('Suspending db...')
     await this.storage.db.suspend()

--- a/test/basic.js
+++ b/test/basic.js
@@ -484,11 +484,13 @@ test('open readOnly', async function (t) {
   const dir = await tmp(t)
 
   const store = new Corestore(dir)
+  await store.ready()
   t.teardown(() => store.close())
 
   const storeReadOnly = new Corestore(dir, {
     readOnly: true
   })
+  await storeReadOnly.ready()
   t.teardown(() => storeReadOnly.close())
 
   t.absent(store.readOnly)

--- a/test/basic.js
+++ b/test/basic.js
@@ -480,6 +480,30 @@ test('manifest is persisted', async function (t) {
   }
 })
 
+test('open readOnly', async function (t) {
+  const dir = await tmp(t)
+
+  const store = new Corestore(dir)
+  t.teardown(() => store.close())
+
+  const storeReadOnly = new Corestore(dir, {
+    readOnly: true
+  })
+  t.teardown(() => storeReadOnly.close())
+
+  t.absent(store.readOnly)
+  t.ok(storeReadOnly.readOnly)
+  t.ok(storeReadOnly.storage.readOnly)
+
+  t.is(storeReadOnly.storage.db.path, store.storage.db.path)
+
+  await storeReadOnly.suspend()
+  await storeReadOnly.resume()
+
+  t.ok(storeReadOnly.readOnly)
+  t.ok(storeReadOnly.storage.readOnly)
+})
+
 function toArray(stream) {
   return new Promise((resolve, reject) => {
     const all = []


### PR DESCRIPTION
This skips flush on readonly to avoid error.



Currently on readonly, `db.suspend` will get `segmentation fault` if the DB is not ready yet when we then try and suspend it. Will handle that in `hypercore-storage` changes in new future.

Note: without this change, we will get a `flush not allowed for read only` error. So we may want to decide which we prefer until downstream updated.