### PR TITLE
Add docs & test for `store.staticify()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ swarm.on('connection', (connection) => store.replicate(connection))
 
 #### `const staticCore = await store.staticify(core, opts = {})`
 
-Create a static version of the passed Hypercore `core`. Static Hypercores are read only and have no signers so cannot be updated by anyone. This is useful for creating content addressed cores that are immutable.
+Create a static version of the passed Hypercore `core`. Static Hypercores are read only and have no signers so cannot be updated by anyone. This is useful for creating content addressed cores that are immutable. `opts` are the same opts as `store.get()` with only `discoveryKey` & `key` options being ignored as they are derived when creating the static core.
 
 #### `const storeB = storeA.session()`
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ swarm.join(...)
 swarm.on('connection', (connection) => store.replicate(connection))
 ```
 
+#### `const staticCore = await store.staticify(core, opts = {})`
+
+Create a static version of the passed Hypercore `core`. Static Hypercores are read only and have no signers so cannot be updated by anyone. This is useful for creating content addressed cores that are immutable.
+
 #### `const storeB = storeA.session()`
 
 Create a new Corestore session. Closing a session will close all cores made from this session.


### PR DESCRIPTION
Add test for `store.staticify()` method & docs.

Test covers:
- error when creating a static version of an empty core
- append throws on a static core
- tree hash matches original core
- original core can be appended to & diverges from static copy
- static version has no signers
