### PR TITLE
Pass original core as dependency when creating a static core

### DIFF
--- a/index.js
+++ b/index.js
@@ -489,7 +489,16 @@ class Corestore extends ReadyResource {
       key: null,
       discoveryKey: null,
       manifest,
-      core: core.state.storage.core
+      core: {
+        ...core.state.storage.core,
+        dependencies: [
+          ...core.state.storage.dependencies,
+          {
+            dataPointer: core.state.storage.core.dataPointer,
+            length: head.length
+          }
+        ]
+      }
     }
 
     c.key = Hypercore.key(c.manifest)


### PR DESCRIPTION
Using the original core as a dependency allows the original core to continue modifying without breaking the static core due to updating head.

Requires https://github.com/holepunchto/hypercore-storage/pull/98