### PR TITLE
Fire `group-active` via `group-update` from core session

### DIFF
--- a/index.js
+++ b/index.js
@@ -684,6 +684,7 @@ class Corestore extends ReadyResource {
     core.onidle = () => {
       this.cores.gc(core)
     }
+
     core.ongroupupdate = (key) => {
       this.emit('group-active', key)
     }

--- a/index.js
+++ b/index.js
@@ -259,6 +259,16 @@ class Corestore extends ReadyResource {
     this.watchers = null
     this.watchIndex = -1
 
+    // Group notification
+    this.groupNotifiers = new Map()
+    this.on('group-active', (topic) => {
+      const topicHex = topic.toString('hex')
+      if (!this.groupNotifiers.has(topicHex)) return
+
+      const fns = this.groupNotifiers.get(topicHex)
+      for (const fn of fns) fn()
+    })
+
     this._findingPeers = null // here for legacy
     this._ongcBound = this._ongc.bind(this)
 
@@ -288,6 +298,27 @@ class Corestore extends ReadyResource {
     if (this.watchers.size === 0) {
       this.watchers = null
       this.cores.unwatch(this)
+    }
+  }
+
+  notifyGroup(topic, fn) {
+    const topicHex = topic.toString('hex')
+
+    const existing = this.groupNotifiers.get(topicHex) || []
+    this.groupNotifiers.set(topicHex, existing.concat(fn))
+  }
+
+  unnotifyGroup(topic, fn) {
+    const topicHex = topic.toString('hex')
+    if (!this.groupNotifiers.has(topicHex)) return
+
+    const existing = this.groupNotifiers.get(topicHex) || []
+    const remainder = existing.filter((f) => f !== fn)
+
+    if (remainder.length) {
+      this.groupNotifiers.set(topicHex, remainder)
+    } else {
+      this.groupNotifiers.delete(topicHex)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -576,11 +576,6 @@ class Corestore extends ReadyResource {
   _makeSession(conf) {
     const session = new Hypercore(null, null, conf)
 
-    // needs a better way
-    session.on('group-update', (key) => {
-      this.emit('group-active', key)
-    })
-
     if (this._findingPeers !== null) this._findingPeers.add(session)
     return session
   }
@@ -688,6 +683,9 @@ class Corestore extends ReadyResource {
 
     core.onidle = () => {
       this.cores.gc(core)
+    }
+    core.ongroupupdate = (key) => {
+      this.emit('group-active', key)
     }
 
     core.replicator.ondownloading = () => {

--- a/index.js
+++ b/index.js
@@ -320,6 +320,8 @@ class Corestore extends ReadyResource {
   }
 
   _removeGroupNotify(handle) {
+    if (handle.index === -1) return
+
     const topicHex = b4a.toString(handle._topic, 'hex')
     const handles = this._groupNotifiers.get(topicHex)
     if (!handles) return
@@ -327,6 +329,7 @@ class Corestore extends ReadyResource {
     const popped = handles.pop()
     if (popped !== handle) handles[(popped.index = handle.index)] = popped
     if (handles.length === 0) this._groupNotifiers.delete(topicHex)
+    handle.index = -1
   }
 
   findingPeers() {

--- a/index.js
+++ b/index.js
@@ -577,8 +577,8 @@ class Corestore extends ReadyResource {
     const session = new Hypercore(null, null, conf)
 
     // needs a better way
-    session.on('append', () => {
-      if (session.core.header.group) this.emit('group-active', session.core.header.group.key)
+    session.on('group-update', (key) => {
+      this.emit('group-active', key)
     })
 
     if (this._findingPeers !== null) this._findingPeers.add(session)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { isAndroid } = require('which-runtime')
 const { STORAGE_EMPTY, ASSERTION } = require('hypercore-errors')
 
 const auditStore = require('./lib/audit.js')
+const GroupNotifyHandle = require('./lib/notify.js')
 
 const [NS] = crypto.namespace('corestore', 1)
 const DEFAULT_NAMESPACE = b4a.alloc(32) // This is meant to be 32 0-bytes
@@ -259,18 +260,10 @@ class Corestore extends ReadyResource {
     this.watchers = null
     this.watchIndex = -1
 
-    // Group notification
-    this.groupNotifiers = new Map()
-    this.on('group-active', (topic) => {
-      const topicHex = topic.toString('hex')
-      if (!this.groupNotifiers.has(topicHex)) return
-
-      const fns = this.groupNotifiers.get(topicHex)
-      for (const fn of fns) fn()
-    })
-
+    this._groupNotifiers = new Map() // group notifications
     this._findingPeers = null // here for legacy
     this._ongcBound = this._ongc.bind(this)
+    this._onGroupActiveBound = this._onGroupActive.bind(this)
 
     if (opts.primaryKey && !this.root && !opts.unsafe) {
       throw ASSERTION(
@@ -301,25 +294,39 @@ class Corestore extends ReadyResource {
     }
   }
 
-  notifyGroup(topic, fn) {
-    const topicHex = topic.toString('hex')
+  _onGroupActive(topic) {
+    this.emit('group-active', topic)
 
-    const existing = this.groupNotifiers.get(topicHex) || []
-    this.groupNotifiers.set(topicHex, existing.concat(fn))
+    const topicHex = b4a.toString(topic, 'hex')
+    const handles = this._groupNotifiers.get(topicHex)
+    if (!handles) return
+    for (const handle of handles) handle.emit('update')
   }
 
-  unnotifyGroup(topic, fn) {
-    const topicHex = topic.toString('hex')
-    if (!this.groupNotifiers.has(topicHex)) return
+  notifyGroup(topic) {
+    const topicHex = b4a.toString(topic, 'hex')
+    let handles = this._groupNotifiers.get(topicHex)
 
-    const existing = this.groupNotifiers.get(topicHex) || []
-    const remainder = existing.filter((f) => f !== fn)
-
-    if (remainder.length) {
-      this.groupNotifiers.set(topicHex, remainder)
-    } else {
-      this.groupNotifiers.delete(topicHex)
+    if (!handles) {
+      handles = []
+      this._groupNotifiers.set(topicHex, handles)
     }
+
+    const handle = new GroupNotifyHandle(this, topic)
+    const length = handles.push(handle)
+    handle.index = length - 1
+
+    return handle
+  }
+
+  _removeGroupNotify(handle) {
+    const topicHex = b4a.toString(handle._topic, 'hex')
+    const handles = this._groupNotifiers.get(topicHex)
+    if (!handles) return
+
+    const popped = handles.pop()
+    if (popped !== handle) handles[(popped.index = handle.index)] = popped
+    if (handles.length === 0) this._groupNotifiers.delete(topicHex)
   }
 
   findingPeers() {
@@ -547,11 +554,8 @@ class Corestore extends ReadyResource {
     return staticCore
   }
 
-  async *getGroupUpdates(topic, opts) {
-    const id = await this.storage.getGroup(topic)
-    if (id === null) return
-
-    yield* this.storage.createGroupUpdateStream(id, opts)
+  getGroupUpdates(topic, opts) {
+    return new GroupNotifyHandle(this, topic).updates(opts)
   }
 
   get(opts) {
@@ -716,9 +720,7 @@ class Corestore extends ReadyResource {
       this.cores.gc(core)
     }
 
-    core.ongroupupdate = (key) => {
-      this.emit('group-active', key)
-    }
+    core.ongroupupdate = this._onGroupActiveBound
 
     core.replicator.ondownloading = () => {
       if (this.active) this.streamTracker.attachAll(core)

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -6,24 +6,15 @@ class GroupNotifyHandle extends EventEmitter {
     super()
     this._store = store
     this._topic = topic
-    this._groupId = null
     this.index = -1
   }
 
   updates(opts) {
-    const self = this
-    const trigger = new Readable({
-      async open(cb) {
-        self._groupId = await self._store.storage.getGroup(self._topic).catch(noop)
-        if (self._groupId !== null) {
-          this.push(self._store.storage.createGroupUpdateStream(self._groupId, opts))
-        }
-        this.push(null)
-        cb(null)
-      }
+    return Readable.deferred(async () => {
+      const groupId = await this._store.storage.getGroup(this._topic).catch(noop)
+      if (groupId === null) return null
+      return this._store.storage.createGroupUpdateStream(groupId, opts)
     })
-
-    return Readable.DeferredStream(trigger)
   }
 
   destroy() {

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,0 +1,33 @@
+const { EventEmitter } = require('events')
+const { PassThrough, pipeline } = require('streamx')
+
+class GroupNotifyHandle extends EventEmitter {
+  constructor(store, topic) {
+    super()
+    this._store = store
+    this._topic = topic
+    this.index = -1
+  }
+
+  updates(opts) {
+    const out = new PassThrough()
+
+    this._store.storage
+      .getGroup(this._topic)
+      .then((id) => {
+        if (id === null) return out.end()
+        pipeline(this._store.storage.createGroupUpdateStream(id, opts), out, noop)
+      })
+      .catch((err) => out.destroy(err))
+
+    return out
+  }
+
+  destroy() {
+    this._store._removeGroupNotify(this)
+  }
+}
+
+module.exports = GroupNotifyHandle
+
+function noop() {}

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,26 +1,29 @@
 const { EventEmitter } = require('events')
-const { PassThrough, pipeline } = require('streamx')
+const { Readable } = require('streamx')
 
 class GroupNotifyHandle extends EventEmitter {
   constructor(store, topic) {
     super()
     this._store = store
     this._topic = topic
+    this._groupId = null
     this.index = -1
   }
 
   updates(opts) {
-    const out = new PassThrough()
+    const self = this
+    const trigger = new Readable({
+      async open(cb) {
+        self._groupId = await self._store.storage.getGroup(self._topic).catch(noop)
+        if (self._groupId !== null) {
+          this.push(self._store.storage.createGroupUpdateStream(self._groupId, opts))
+        }
+        this.push(null)
+        cb(null)
+      }
+    })
 
-    this._store.storage
-      .getGroup(this._topic)
-      .then((id) => {
-        if (id === null) return out.end()
-        pipeline(this._store.storage.createGroupUpdateStream(id, opts), out, noop)
-      })
-      .catch((err) => out.destroy(err))
-
-    return out
+    return Readable.DeferredStream(trigger)
   }
 
   destroy() {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hypercore-id-encoding": "^1.3.0",
     "ready-resource": "^1.1.1",
     "sodium-universal": "^5.0.1",
+    "streamx": "^2.25.0",
     "which-runtime": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,15 @@
     "index.js",
     "lib/*"
   ],
+  "imports": {
+    "events": {
+      "bare": "bare-events",
+      "default": "events"
+    }
+  },
   "dependencies": {
     "b4a": "^1.6.7",
+    "bare-events": "^2.8.3",
     "hypercore": "^11.31.0",
     "hypercore-crypto": "^3.4.2",
     "hypercore-errors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hypercore-id-encoding": "^1.3.0",
     "ready-resource": "^1.1.1",
     "sodium-universal": "^5.0.1",
-    "streamx": "^2.25.0",
+    "streamx": "^2.26.0",
     "which-runtime": "^1.2.1"
   },
   "devDependencies": {

--- a/test/all.js
+++ b/test/all.js
@@ -9,6 +9,7 @@ async function runTests() {
 
   await import('./basic.js')
   await import('./groups.js')
+  await import('./notify.js')
 
   test.resume()
 }

--- a/test/groups.js
+++ b/test/groups.js
@@ -110,8 +110,10 @@ test('group-active - fired per core not per session', async function (t) {
   const store = await create(t)
 
   const a = store.get({ name: 'foo', group: topic })
+  await a.ready()
   t.teardown(() => a.close())
   const a2 = store.get({ name: 'foo' })
+  await a2.ready()
   t.teardown(() => a2.close())
 
   store.on('group-active', (group) => {

--- a/test/groups.js
+++ b/test/groups.js
@@ -121,6 +121,36 @@ test('group-active - fired per core not per session', async function (t) {
   await a.append('hello')
 })
 
+test('group-active - fired via passive', async function (t) {
+  t.plan(2)
+  const topic = b4a.alloc(32, 1)
+
+  const store = await create(t)
+
+  const dir = await t.tmp()
+  let store2 = new Corestore(dir)
+
+  const a = store.get({ name: 'foo', group: topic })
+  await a.ready()
+
+  const a2 = store2.get({ key: a.key, group: topic })
+  t.teardown(() => a2.close())
+  await a2.ready()
+
+  await store2.close()
+
+  store2 = new Corestore(dir)
+  t.teardown(() => store2.close())
+
+  store2.on('group-active', (group) => {
+    t.alike(group, topic, 'group active from passive core')
+  })
+  replicate(t, store, store2)
+
+  t.absent(store2.cores.map.has(a.key.toString('hex')), 'reopened store2 doesnt have core loaded')
+  await a.append('hello')
+})
+
 test('(un)notifyGroup', async function (t) {
   t.plan(4)
   const topic = b4a.alloc(32, 1)
@@ -144,6 +174,25 @@ test('(un)notifyGroup', async function (t) {
 
   await a.append('hello')
 })
+
+function replicate(t, a, b) {
+  const s1 = a.replicate(true)
+  const s2 = b.replicate(false)
+
+  s1.pipe(s2).pipe(s1)
+
+  s1.on('error', console.error)
+  s2.on('error', console.error)
+
+  t.teardown(async () => {
+    s1.destroy()
+    s2.destroy()
+    await Promise.all([
+      new Promise((resolve) => s1.once('close', resolve)),
+      new Promise((resolve) => s2.once('close', resolve))
+    ])
+  })
+}
 
 function includesKey(keys, key) {
   return keys.find((k) => k.toString('hex') === key.toString('hex'))

--- a/test/groups.js
+++ b/test/groups.js
@@ -103,6 +103,24 @@ test('group - persistance', async function (t) {
   await store3.close()
 })
 
+test('group-active - fired per core not per session', async function (t) {
+  t.plan(1)
+  const topic = b4a.alloc(32, 1)
+
+  const store = await create(t)
+
+  const a = store.get({ name: 'foo', group: topic })
+  t.teardown(() => a.close())
+  const a2 = store.get({ name: 'foo' })
+  t.teardown(() => a2.close())
+
+  store.on('group-active', (group) => {
+    t.is(group, topic, 'group active')
+  })
+
+  await a.append('hello')
+})
+
 function includesKey(keys, key) {
   return keys.find((k) => k.toString('hex') === key.toString('hex'))
 }

--- a/test/groups.js
+++ b/test/groups.js
@@ -3,6 +3,7 @@ const b4a = require('b4a')
 
 const Corestore = require('../')
 const { create, toArray, includesKey } = require('./helpers')
+const GroupNotifyHandle = require('../lib/notify')
 
 test('groups', async function (t) {
   t.plan(3)
@@ -183,6 +184,28 @@ test('notifyGroup handle - updates empty for unknown topic', async function (t) 
   const handle = store.notifyGroup(b4a.alloc(32, 99))
   t.alike(await toArray(handle.updates()), [], 'empty stream when topic has no group')
   handle.destroy()
+})
+
+test('notifyGroup - passed handle never attached ends early', async function (t) {
+  const store = await create(t)
+
+  const topic = b4a.alloc(32, 1)
+  const legit = store.notifyGroup(topic)
+  t.teardown(() => legit.destroy())
+
+  const handle = new GroupNotifyHandle(store, b4a.alloc(32, 1))
+  t.is(handle.index, -1, 'non-attached handle has index -1')
+  t.execution(() => handle.destroy(), 'destroy runs w/o issue')
+
+  t.not(legit.index, -1, 'legit index wasnt updated')
+
+  const a = store.get({ name: 'a', group: topic })
+  await a.ready()
+  t.teardown(() => a.close())
+
+  await a.append('boo')
+
+  t.ok(includesKey(await toArray(handle.updates()), a.key), 'legit updates stream returns key')
 })
 
 function replicate(t, a, b) {

--- a/test/groups.js
+++ b/test/groups.js
@@ -2,7 +2,7 @@ const test = require('brittle')
 const b4a = require('b4a')
 
 const Corestore = require('../')
-const { create, toArray } = require('./helpers')
+const { create, toArray, includesKey } = require('./helpers')
 
 test('groups', async function (t) {
   t.plan(3)
@@ -151,8 +151,8 @@ test('group-active - fired via passive', async function (t) {
   await a.append('hello')
 })
 
-test('(un)notifyGroup', async function (t) {
-  t.plan(4)
+test('notifyGroup handle', async function (t) {
+  t.plan(5)
   const topic = b4a.alloc(32, 1)
 
   const store = await create(t)
@@ -160,19 +160,27 @@ test('(un)notifyGroup', async function (t) {
   const a = store.get({ name: 'foo', group: topic })
   t.teardown(() => a.close())
 
-  const handler = () => {
-    t.pass('notified')
-  }
-  store.notifyGroup(b4a.alloc(32, 1), handler)
-  t.ok(store.groupNotifiers.has(topic.toString('hex')), 'registered handler in map')
+  const handle = store.notifyGroup(b4a.alloc(32, 1))
+  t.ok(store._groupNotifiers.has(topic.toString('hex')), 'registered handle in map')
+
+  handle.on('update', () => t.pass('notified'))
 
   await a.append('hello')
   await a.append('hello') // fires each time
 
-  store.unnotifyGroup(b4a.alloc(32, 1), handler)
-  t.is(store.groupNotifiers.size, 0, 'cleared handler')
+  t.ok(includesKey(await toArray(handle.updates()), a.key), 'updates stream returns key')
+
+  handle.destroy()
+  t.is(store._groupNotifiers.size, 0, 'cleared handle')
 
   await a.append('hello')
+})
+
+test('notifyGroup handle - updates empty for unknown topic', async function (t) {
+  const store = await create(t)
+  const handle = store.notifyGroup(b4a.alloc(32, 99))
+  t.alike(await toArray(handle.updates()), [], 'empty stream when topic has no group')
+  handle.destroy()
 })
 
 function replicate(t, a, b) {
@@ -192,8 +200,4 @@ function replicate(t, a, b) {
       new Promise((resolve) => s2.once('close', resolve))
     ])
   })
-}
-
-function includesKey(keys, key) {
-  return keys.find((k) => k.toString('hex') === key.toString('hex'))
 }

--- a/test/groups.js
+++ b/test/groups.js
@@ -121,6 +121,30 @@ test('group-active - fired per core not per session', async function (t) {
   await a.append('hello')
 })
 
+test('(un)notifyGroup', async function (t) {
+  t.plan(4)
+  const topic = b4a.alloc(32, 1)
+
+  const store = await create(t)
+
+  const a = store.get({ name: 'foo', group: topic })
+  t.teardown(() => a.close())
+
+  const handler = () => {
+    t.pass('notified')
+  }
+  store.notifyGroup(b4a.alloc(32, 1), handler)
+  t.ok(store.groupNotifiers.has(topic.toString('hex')), 'registered handler in map')
+
+  await a.append('hello')
+  await a.append('hello') // fires each time
+
+  store.unnotifyGroup(b4a.alloc(32, 1), handler)
+  t.is(store.groupNotifiers.size, 0, 'cleared handler')
+
+  await a.append('hello')
+})
+
 function includesKey(keys, key) {
   return keys.find((k) => k.toString('hex') === key.toString('hex'))
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -15,7 +15,12 @@ async function create(t) {
   return store
 }
 
+function includesKey(keys, key) {
+  return keys.find((k) => k.toString('hex') === key.toString('hex'))
+}
+
 module.exports = {
   toArray,
-  create
+  create,
+  includesKey
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,4 +1,5 @@
 const Corestore = require('../..')
+const b4a = require('b4a')
 
 async function toArray(ite) {
   const all = []
@@ -16,7 +17,7 @@ async function create(t) {
 }
 
 function includesKey(keys, key) {
-  return keys.find((k) => k.toString('hex') === key.toString('hex'))
+  return keys.find((k) => b4a.toString(k, 'hex') === b4a.toString(key, 'hex'))
 }
 
 module.exports = {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -17,7 +17,7 @@ async function create(t) {
 }
 
 function includesKey(keys, key) {
-  return keys.find((k) => b4a.toString(k, 'hex') === b4a.toString(key, 'hex'))
+  return keys.find((k) => b4a.equals(k, key))
 }
 
 module.exports = {

--- a/test/notify.js
+++ b/test/notify.js
@@ -1,0 +1,99 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const { create, toArray, includesKey } = require('./helpers')
+
+test('notify handler - empty when no cores in group', async function (t) {
+  const store = await create(t)
+  const handle = store.notifyGroup(b4a.alloc(32, 1))
+  t.teardown(() => handle.destroy())
+  t.alike(await toArray(handle.updates()), [])
+})
+
+test('notify handler - returns keys of cores that have been active in group', async function (t) {
+  const store = await create(t)
+  const topic = b4a.alloc(32, 1)
+
+  const a = store.get({ name: 'a', group: topic })
+  const b = store.get({ name: 'b', group: topic })
+  await a.append('hello')
+  await b.append('world')
+
+  const handle = store.notifyGroup(topic)
+  t.teardown(() => handle.destroy())
+
+  const keys = await toArray(handle.updates())
+  t.ok(includesKey(keys, a.key), 'a key present')
+  t.ok(includesKey(keys, b.key), 'b key present')
+})
+
+test('notify handler - stream can be abandoned mid-read without hanging', async function (t) {
+  const store = await create(t)
+  const topic = b4a.alloc(32, 1)
+  const a = store.get({ name: 'a', group: topic })
+  await a.append('hello')
+
+  const handle = store.notifyGroup(topic)
+  t.teardown(() => handle.destroy())
+
+  const stream = handle.updates()
+  const close = new Promise((resolve) => stream.on('close', resolve))
+  // user gives up on the stream immediately
+  stream.destroy()
+  await close
+  t.pass('closed cleanly')
+})
+
+test('notify handler - multiple independent streams from same handle', async function (t) {
+  const store = await create(t)
+  const topic = b4a.alloc(32, 1)
+  const a = store.get({ name: 'a', group: topic })
+  await a.append('hello')
+
+  const handle = store.notifyGroup(topic)
+  t.teardown(() => handle.destroy())
+
+  const [keys1, keys2] = await Promise.all([toArray(handle.updates()), toArray(handle.updates())])
+
+  t.ok(includesKey(keys1, a.key), 'a key present in first stream')
+  t.ok(includesKey(keys2, a.key), 'a key present in second stream')
+})
+
+test('notify handler - destroy stops update events from firing', async function (t) {
+  const store = await create(t)
+  const topic = b4a.alloc(32, 1)
+  const a = store.get({ name: 'a', group: topic })
+
+  const handle = store.notifyGroup(topic)
+  let count = 0
+  handle.on('update', () => count++)
+
+  await a.append('one')
+  handle.destroy()
+  await a.append('two')
+
+  t.is(count, 1, 'only fired before destroy')
+})
+
+test('notify handler - update events continue on other handles', async function (t) {
+  t.plan(1)
+  const store = await create(t)
+  const topic = b4a.alloc(32, 1)
+  const a = store.get({ name: 'a', group: topic })
+
+  const h1 = store.notifyGroup(topic)
+  const h2 = store.notifyGroup(topic)
+  t.teardown(() => h2.destroy())
+
+  h2.on('update', () => t.pass('h2 still fires'))
+  h1.destroy()
+
+  await a.append('hello')
+})
+
+test('notify handler - destroy called twice does not throw', async function (t) {
+  const store = await create(t)
+  const handle = store.notifyGroup(b4a.alloc(32, 1))
+  handle.destroy()
+  handle.destroy()
+  t.pass()
+})


### PR DESCRIPTION
Checking the `group` in the header is not need as the event only fires if the core has a group.

Depends on:
- https://github.com/holepunchto/hypercore/pull/820