### PR TITLE
feat: Forward core data: key/length/fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,13 +294,13 @@ class Corestore extends ReadyResource {
     }
   }
 
-  _onGroupActive(topic, core) {
-    this.emit('group-active', topic, core)
+  _onGroupActive(topic, update) {
+    this.emit('group-active', topic, update)
 
     const topicHex = b4a.toString(topic, 'hex')
     const handles = this._groupNotifiers.get(topicHex)
     if (!handles) return
-    for (const handle of handles) handle.emit('update', core)
+    for (const handle of handles) handle.emit('update', update)
   }
 
   notifyGroup(topic) {

--- a/index.js
+++ b/index.js
@@ -294,13 +294,13 @@ class Corestore extends ReadyResource {
     }
   }
 
-  _onGroupActive(topic) {
-    this.emit('group-active', topic)
+  _onGroupActive(topic, core) {
+    this.emit('group-active', topic, core)
 
     const topicHex = b4a.toString(topic, 'hex')
     const handles = this._groupNotifiers.get(topicHex)
     if (!handles) return
-    for (const handle of handles) handle.emit('update')
+    for (const handle of handles) handle.emit('update', core)
   }
 
   notifyGroup(topic) {

--- a/test/groups.js
+++ b/test/groups.js
@@ -161,7 +161,7 @@ test('group-active - fired via passive', async function (t) {
 })
 
 test('notifyGroup handle', async function (t) {
-  t.plan(7)
+  t.plan(11)
   const topic = b4a.alloc(32, 1)
 
   const store = await create(t)
@@ -182,44 +182,19 @@ test('notifyGroup handle', async function (t) {
   await a.append('hello') // fires each time
 
   t.ok(includesKey(await toArray(handle.updates()), a.key), 'updates stream returns key')
-  t.alike(
-    events,
-    [
-      {
-        key: a.key,
-        length: 1,
-        fork: 0
-      },
-      {
-        key: a.key,
-        length: 2,
-        fork: 0
-      }
-    ],
-    'has update events'
-  )
+  t.is(events.length, 2, 'events added to')
+
+  t.alike(events[0].key, a.key)
+  t.is(events[0].length, 1)
+
+  t.alike(events[1].key, a.key)
+  t.is(events[1].length, 2)
 
   handle.destroy()
   t.is(store._groupNotifiers.size, 0, 'cleared handle')
 
   await a.append('hello')
-
-  t.alike(
-    events,
-    [
-      {
-        key: a.key,
-        length: 1,
-        fork: 0
-      },
-      {
-        key: a.key,
-        length: 2,
-        fork: 0
-      }
-    ],
-    'events not added to'
-  )
+  t.is(events.length, 2, 'events not added to')
 })
 
 test('notifyGroup handle - updates empty for unknown topic', async function (t) {

--- a/test/groups.js
+++ b/test/groups.js
@@ -105,7 +105,7 @@ test('group - persistance', async function (t) {
 })
 
 test('group-active - fired per core not per session', async function (t) {
-  t.plan(1)
+  t.plan(4)
   const topic = b4a.alloc(32, 1)
 
   const store = await create(t)
@@ -117,7 +117,10 @@ test('group-active - fired per core not per session', async function (t) {
   await a2.ready()
   t.teardown(() => a2.close())
 
-  store.on('group-active', (group) => {
+  store.on('group-active', (group, { key, length, fork }) => {
+    t.ok(b4a.equals(a.core.key, key))
+    t.is(length, 1)
+    t.is(fork, 0)
     t.is(group, topic, 'group active')
   })
 
@@ -125,7 +128,7 @@ test('group-active - fired per core not per session', async function (t) {
 })
 
 test('group-active - fired via passive', async function (t) {
-  t.plan(2)
+  t.plan(5)
   const topic = b4a.alloc(32, 1)
 
   const store = await create(t)
@@ -145,7 +148,10 @@ test('group-active - fired via passive', async function (t) {
   store2 = new Corestore(dir)
   t.teardown(() => store2.close())
 
-  store2.on('group-active', (group) => {
+  store2.on('group-active', (group, { key, length, fork }) => {
+    t.ok(b4a.equals(a.core.key, key))
+    t.is(length, 1)
+    t.is(fork, 0)
     t.alike(group, topic, 'group active from passive core')
   })
   replicate(t, store, store2)
@@ -155,7 +161,7 @@ test('group-active - fired via passive', async function (t) {
 })
 
 test('notifyGroup handle', async function (t) {
-  t.plan(5)
+  t.plan(7)
   const topic = b4a.alloc(32, 1)
 
   const store = await create(t)
@@ -166,17 +172,54 @@ test('notifyGroup handle', async function (t) {
   const handle = store.notifyGroup(b4a.alloc(32, 1))
   t.ok(store._groupNotifiers.has(topic.toString('hex')), 'registered handle in map')
 
-  handle.on('update', () => t.pass('notified'))
+  const events = []
+  handle.on('update', (core) => {
+    t.pass('notified')
+    events.push(core)
+  })
 
   await a.append('hello')
   await a.append('hello') // fires each time
 
   t.ok(includesKey(await toArray(handle.updates()), a.key), 'updates stream returns key')
+  t.alike(
+    events,
+    [
+      {
+        key: a.key,
+        length: 1,
+        fork: 0
+      },
+      {
+        key: a.key,
+        length: 2,
+        fork: 0
+      }
+    ],
+    'has update events'
+  )
 
   handle.destroy()
   t.is(store._groupNotifiers.size, 0, 'cleared handle')
 
   await a.append('hello')
+
+  t.alike(
+    events,
+    [
+      {
+        key: a.key,
+        length: 1,
+        fork: 0
+      },
+      {
+        key: a.key,
+        length: 2,
+        fork: 0
+      }
+    ],
+    'events not added to'
+  )
 })
 
 test('notifyGroup handle - updates empty for unknown topic', async function (t) {

--- a/test/groups.js
+++ b/test/groups.js
@@ -118,7 +118,7 @@ test('group-active - fired per core not per session', async function (t) {
   t.teardown(() => a2.close())
 
   store.on('group-active', (group, { key, length, fork }) => {
-    t.ok(b4a.equals(a.core.key, key))
+    t.alike(a.core.key, key)
     t.is(length, 1)
     t.is(fork, 0)
     t.is(group, topic, 'group active')
@@ -149,7 +149,7 @@ test('group-active - fired via passive', async function (t) {
   t.teardown(() => store2.close())
 
   store2.on('group-active', (group, { key, length, fork }) => {
-    t.ok(b4a.equals(a.core.key, key))
+    t.alike(a.core.key, key)
     t.is(length, 1)
     t.is(fork, 0)
     t.alike(group, topic, 'group active from passive core')


### PR DESCRIPTION
`group-active` and notify handler on `update` get core key/length/fork
