### PR TITLE
Add `treeCache` option, doc & test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
 {
   primaryKey: null, // The primary key to use as the master key for key derivation.
   writable: true,
+  treeCache: { maxSize: 8192 } // Options to use when creating hypercore's default storage
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -243,7 +243,8 @@ class Corestore extends ReadyResource {
           id: opts.id,
           allowBackup: opts.allowBackup,
           readOnly: opts.readOnly,
-          wait: opts.wait
+          wait: opts.wait,
+          treeCache: opts.treeCache
         })
     this.streamTracker = this.root ? this.root.streamTracker : new StreamTracker()
     this.cores = this.root ? this.root.cores : new CoreTracker()

--- a/test/basic.js
+++ b/test/basic.js
@@ -86,6 +86,17 @@ test('pass primary key', async function (t) {
   }
 })
 
+test('pass treeCache options', async (t) => {
+  const dir = await t.tmp()
+
+  const store = new Corestore(dir, { treeCache: { maxSize: 128, maxAge: 1337 } })
+  await store.ready()
+
+  t.is(store.storage.treeCache.maxSize, 128, 'set maxSize')
+  t.is(store.storage.treeCache.maxAge, 1337, 'set maxAge')
+  await store.close()
+})
+
 test('global cache is passed down', async function (t) {
   const dir = await t.tmp()
   const store = new Corestore(dir, { globalCache: new Rache({ maxSize: 4 }) })


### PR DESCRIPTION
Follow up to:
- https://github.com/holepunchto/hypercore-storage/pull/124
- https://github.com/holepunchto/hypercore/pull/840

Allows configuring the tree node cache options. Useful for things like `blind-peer` which likely needs higher `maxSize` given they tend to serve more peers than normal.