### PR TITLE
add suspend and resume replication

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const b4a = require('b4a')
 const Hypercore = require('hypercore')
+const { SuspendController } = require('hypercore')
 const ReadyResource = require('ready-resource')
 const sodium = require('sodium-universal')
 const crypto = require('hypercore-crypto')
@@ -248,6 +249,7 @@ class Corestore extends ReadyResource {
         })
     this.streamTracker = this.root ? this.root.streamTracker : new StreamTracker()
     this.cores = this.root ? this.root.cores : new CoreTracker()
+    this._suspendController = this.root ? this.root._suspendController : new SuspendController()
     this.sessions = new SessionTracker()
     this.corestores = this.root ? this.root.corestores : new Set()
     this.readOnly = opts.writable === false || !!opts.readOnly
@@ -363,6 +365,20 @@ class Corestore extends ReadyResource {
 
   resume() {
     return this.storage.resume()
+  }
+
+  // pauses replication on every core, both ways, but keeps peers connected,
+  // when this resolves replication issues no more storage operations
+  async suspendReplication() {
+    this._suspendController.suspend()
+
+    for (const core of this.cores.map.values()) {
+      while (!core.closing && core.replicator.busy) await immediate()
+    }
+  }
+
+  resumeReplication() {
+    this._suspendController.resume()
   }
 
   session(opts) {
@@ -717,6 +733,7 @@ class Corestore extends ReadyResource {
       manifest: auth.manifest,
       group: auth.group,
       globalCache: opts.globalCache || this.globalCache || null,
+      suspendSignal: this._suspendController.signal,
       alias: opts.name ? { name: opts.name, namespace: this.ns } : null
     })
 
@@ -767,6 +784,10 @@ function createKeyPair(primaryKey, namespace, name) {
 }
 
 function noop() {}
+
+function immediate() {
+  return new Promise(setImmediate)
+}
 
 function toHex(discoveryKey) {
   return b4a.toString(discoveryKey, 'hex')

--- a/test/all.js
+++ b/test/all.js
@@ -10,6 +10,7 @@ async function runTests() {
   await import('./basic.js')
   await import('./groups.js')
   await import('./notify.js')
+  await import('./suspend-replication.js')
 
   test.resume()
 }

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -1,0 +1,106 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const Corestore = require('../')
+
+test('suspendReplication pauses every core, resume catches up', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const foo = store.get({ name: 'foo' })
+  const bar = store.get({ name: 'bar' })
+  await foo.append(['a', 'b'])
+  await bar.append(['x', 'y'])
+
+  const store2 = new Corestore(await t.tmp())
+  const fooClone = store2.get(foo.key)
+  const barClone = store2.get(bar.key)
+
+  const streams = replicate(store, store2, t)
+
+  t.alike(await fooClone.get(0), b4a.from('a'))
+  t.alike(await barClone.get(0), b4a.from('x'))
+
+  await store2.suspendReplication()
+
+  await foo.append('c')
+  await bar.append('z')
+  await sleep(300)
+
+  t.is(fooClone.length, 2, 'foo not upgraded while suspended')
+  t.is(barClone.length, 2, 'bar not upgraded while suspended')
+
+  store2.resumeReplication()
+
+  t.alike(await fooClone.get(2), b4a.from('c'), 'foo caught up after resume')
+  t.alike(await barClone.get(2), b4a.from('z'), 'bar caught up after resume')
+
+  await teardown(streams, store, store2)
+})
+
+test('core opened while suspended comes up suspended', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const a = store.get({ name: 'a' })
+  await a.append(['a', 'b', 'c'])
+
+  const store2 = new Corestore(await t.tmp())
+  await store2.suspendReplication()
+
+  const clone = store2.get(a.key)
+  const streams = replicate(store, store2, t)
+
+  const get = clone.get(1)
+  const early = await Promise.race([get.then(() => 'served'), sleep(300).then(() => 'pending')])
+  t.is(early, 'pending', 'no download while suspended')
+
+  store2.resumeReplication()
+
+  t.alike(await get, b4a.from('b'), 'downloaded after resume')
+
+  await teardown(streams, store, store2)
+})
+
+test('storage suspends cleanly under suspended replication', async function (t) {
+  const store = new Corestore(await t.tmp())
+
+  const a = store.get({ name: 'a' })
+  await a.append(['a', 'b', 'c', 'd', 'e'])
+
+  const store2 = new Corestore(await t.tmp())
+  const clone = store2.get(a.key)
+
+  const streams = replicate(store, store2, t)
+
+  t.alike(await clone.get(0), b4a.from('a'))
+
+  await store.suspendReplication()
+  await store.suspend()
+
+  // incoming request while fully suspended must queue, not park on storage
+  const get = clone.get(3)
+  await sleep(300)
+
+  t.is(store.storage.rocks.diagnostics().io, 0, 'no parked storage io while suspended')
+
+  await store.resume()
+  store.resumeReplication()
+
+  t.alike(await get, b4a.from('d'), 'served after resume')
+
+  await teardown(streams, store, store2)
+})
+
+function replicate(a, b, t) {
+  const s1 = a.replicate(true)
+  const s2 = b.replicate(false)
+  s1.pipe(s2).pipe(s1)
+  return [s1, s2]
+}
+
+async function teardown(streams, ...stores) {
+  for (const s of streams) s.destroy()
+  for (const store of stores) await store.close()
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
Adds a store level way to pause replication without dropping connections, built on the suspend controller from holepunchto/hypercore#851.

The store holds one `SuspendController` and passes its signal to every core it opens, so `suspendReplication()` is a single flip that gates all cores at once, followed by a wait for each replicator to finish in flight work. When it resolves, replication issues no more storage operations, so the underlying storage can be suspended while peers stay connected. Cores opened while suspended come up suspended. `resumeReplication()` flips the signal back and each core serves the requests that queued while suspended and re-requests anything that was dropped, over the same connections. Sessions and namespaces share the root store's controller.

The reason we need this: consumers can briefly suspend the store to release resources and locks, for example suspending the underlying storage, whilst keeping the swarm and peers warm. Without it the only safe option is tearing connections down before suspending, because replication traffic against suspended storage parks forever.

Tests cover a single flip pausing multiple cores and catching up on resume, a core opened mid suspension coming up suspended, and storage suspending cleanly under suspended replication with no parked io while an incoming request waits.

## Dependencies

- holepunchto/hypercore#851 (suspend controller for replication), dep bump included here once it's released. CI is red until then.