### PR TITLE
removes implicit flush on suspend() calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,12 +348,6 @@ class Corestore extends ReadyResource {
   }
 
   async suspend({ log = noop } = {}) {
-    await log('Flushing db...')
-    // If readOnly we don't need to flush
-    if (!this.storage.readOnly) {
-      await this.storage.db.flush()
-      await log('Flusing db completed')
-    }
     if (!this.shouldSuspend) return
     await log('Suspending db...')
     await this.storage.suspend({ log })


### PR DESCRIPTION
Removing the implicit flush for calls to `.suspend()`. Now with WAL filtering opening the database isn't as memory consuming issue anymore as we can control what is append on open.

See: https://github.com/holepunchto/librocksdb/pull/35